### PR TITLE
print out all rmsds

### DIFF
--- a/src/laue_dials/__init__.py
+++ b/src/laue_dials/__init__.py
@@ -2,11 +2,9 @@ import sys
 
 if sys.version_info[:2] >= (3, 8):
     # TODO: Import directly (no need for conditional) when `python_requires = >= 3.8`
-    from importlib.metadata import (PackageNotFoundError,  # pragma: no cover
-                                    version)
+    from importlib.metadata import PackageNotFoundError, version  # pragma: no cover
 else:
-    from importlib_metadata import (PackageNotFoundError,  # pragma: no cover
-                                    version)
+    from importlib_metadata import PackageNotFoundError, version  # pragma: no cover
 
 try:
     # Change here if project is renamed and does not equal the package name

--- a/src/laue_dials/algorithms/laue.py
+++ b/src/laue_dials/algorithms/laue.py
@@ -86,8 +86,9 @@ def gen_beam_models(expts, refls):
     # Imports
     from copy import deepcopy
 
-    from dials.algorithms.refinement.prediction.managed_predictors import \
-        ExperimentsPredictorFactory
+    from dials.algorithms.refinement.prediction.managed_predictors import (
+        ExperimentsPredictorFactory,
+    )
 
     # Instantiate new ExperimentList/reflection_table
     new_expts = ExperimentList()

--- a/src/laue_dials/command_line/compute_rmsds.py
+++ b/src/laue_dials/command_line/compute_rmsds.py
@@ -179,6 +179,7 @@ def run(args=None, *, phil=working_phil):
 
     resid_data = pd.DataFrame({"Image": images, "RMSD (px)": rmsds})
 
+    pd.set_option('display.max_rows', None)
     logger.info(f"RMSDs per image: \n{resid_data}")
 
     # Get pixel size (assume square)

--- a/src/laue_dials/command_line/compute_rmsds.py
+++ b/src/laue_dials/command_line/compute_rmsds.py
@@ -13,8 +13,7 @@ import pandas as pd
 import reciprocalspaceship as rs
 from cctbx import sgtbx
 from dials.util import show_mail_handle_errors
-from dials.util.options import (ArgumentParser,
-                                reflections_and_experiments_from_files)
+from dials.util.options import ArgumentParser, reflections_and_experiments_from_files
 from matplotlib import pyplot as plt
 
 from laue_dials.utils.version import laue_version
@@ -179,7 +178,7 @@ def run(args=None, *, phil=working_phil):
 
     resid_data = pd.DataFrame({"Image": images, "RMSD (px)": rmsds})
 
-    pd.set_option('display.max_rows', None)
+    pd.set_option("display.max_rows", None)
     logger.info(f"RMSDs per image: \n{resid_data}")
 
     # Get pixel size (assume square)

--- a/src/laue_dials/command_line/index.py
+++ b/src/laue_dials/command_line/index.py
@@ -8,11 +8,9 @@ import time
 
 import libtbx.phil
 from dials.util import show_mail_handle_errors
-from dials.util.options import (ArgumentParser,
-                                reflections_and_experiments_from_files)
+from dials.util.options import ArgumentParser, reflections_and_experiments_from_files
 
-from laue_dials.algorithms.monochromatic import (initial_index,
-                                                 scan_varying_refine)
+from laue_dials.algorithms.monochromatic import initial_index, scan_varying_refine
 from laue_dials.utils.version import laue_version
 
 # Print laue-dials + DIALS versions

--- a/src/laue_dials/command_line/integrate.py
+++ b/src/laue_dials/command_line/integrate.py
@@ -17,8 +17,7 @@ import reciprocalspaceship as rs
 from cctbx import sgtbx
 from dials.array_family import flex
 from dials.util import show_mail_handle_errors
-from dials.util.options import (ArgumentParser,
-                                reflections_and_experiments_from_files)
+from dials.util.options import ArgumentParser, reflections_and_experiments_from_files
 
 from laue_dials.algorithms.integration import SegmentedImage
 from laue_dials.utils.version import laue_version

--- a/src/laue_dials/command_line/optimize_indexing.py
+++ b/src/laue_dials/command_line/optimize_indexing.py
@@ -14,8 +14,7 @@ import numpy as np
 from dials.array_family import flex
 from dials.array_family.flex import reflection_table
 from dials.util import show_mail_handle_errors
-from dials.util.options import (ArgumentParser,
-                                reflections_and_experiments_from_files)
+from dials.util.options import ArgumentParser, reflections_and_experiments_from_files
 from dxtbx.model import ExperimentList
 
 from laue_dials.utils.version import laue_version

--- a/src/laue_dials/command_line/plot_wavelengths.py
+++ b/src/laue_dials/command_line/plot_wavelengths.py
@@ -8,8 +8,7 @@ import sys
 
 import libtbx.phil
 from dials.util import show_mail_handle_errors
-from dials.util.options import (ArgumentParser,
-                                reflections_and_experiments_from_files)
+from dials.util.options import ArgumentParser, reflections_and_experiments_from_files
 from matplotlib import pyplot as plt
 
 from laue_dials.utils.version import laue_version

--- a/src/laue_dials/command_line/predict.py
+++ b/src/laue_dials/command_line/predict.py
@@ -16,8 +16,7 @@ from dials.algorithms.spot_prediction import ray_intersection
 from dials.array_family import flex
 from dials.array_family.flex import reflection_table
 from dials.util import show_mail_handle_errors
-from dials.util.options import (ArgumentParser,
-                                reflections_and_experiments_from_files)
+from dials.util.options import ArgumentParser, reflections_and_experiments_from_files
 from dxtbx.model import ExperimentList
 
 from laue_dials.algorithms.outliers import gen_kde

--- a/src/laue_dials/command_line/refine.py
+++ b/src/laue_dials/command_line/refine.py
@@ -19,8 +19,11 @@ from dials.util.options import ArgumentParser
 from dxtbx.model import ExperimentList
 from dxtbx.model.experiment_list import ExperimentListFactory
 
-from laue_dials.algorithms.laue import (gen_beam_models, remove_beam_models,
-                                        store_wavelengths)
+from laue_dials.algorithms.laue import (
+    gen_beam_models,
+    remove_beam_models,
+    store_wavelengths,
+)
 from laue_dials.utils.version import laue_version
 
 # Print laue-dials + DIALS versions

--- a/src/laue_dials/command_line/sequence_to_stills.py
+++ b/src/laue_dials/command_line/sequence_to_stills.py
@@ -14,8 +14,7 @@ import numpy as np
 from dials.array_family import flex
 from dials.array_family.flex import reflection_table
 from dials.util import show_mail_handle_errors
-from dials.util.options import (ArgumentParser,
-                                reflections_and_experiments_from_files)
+from dials.util.options import ArgumentParser, reflections_and_experiments_from_files
 from dxtbx.model import MosaicCrystalSauter2014
 from dxtbx.model.experiment_list import Experiment, ExperimentList
 from libtbx.phil import parse

--- a/tests/algorithms/test_laue.py
+++ b/tests/algorithms/test_laue.py
@@ -5,9 +5,14 @@ import pytest
 from dials.array_family.flex import reflection_table
 from dxtbx.model import ExperimentList
 
-from laue_dials.algorithms.laue import (LaueAssigner, LaueBase, LauePredictor,
-                                        gen_beam_models, remove_beam_models,
-                                        store_wavelengths)
+from laue_dials.algorithms.laue import (
+    LaueAssigner,
+    LaueBase,
+    LauePredictor,
+    gen_beam_models,
+    remove_beam_models,
+    store_wavelengths,
+)
 
 
 @pytest.fixture


### PR DESCRIPTION
now all images' rmsds print, not just the rmsds for images at the beginning and the end of the rotation series.

**before:** 

```The following parameters have been modified:

input {
  experiments = poly_refined.expt
  reflections = poly_refined.refl
}

Total Number of Spots: 13880.
RMSDs per image: 
    Image  RMSD (px)
0       1   0.320343
1       2   0.266309
2       3   0.286786
3       4   0.224967
4       5   0.265169
..    ...        ...
86     87  15.357494
87     88  16.566162
88     89  15.645807
89     90  14.451786
90     91  14.285497

[91 rows x 2 columns]
```

**after:** 

```The following parameters have been modified:

log = "new.log"
input {
  experiments = poly_refined.expt
  reflections = poly_refined.refl
}

Total Number of Spots: 13880.
RMSDs per image: 
    Image  RMSD (px)
0       1   0.320343
1       2   0.266309
2       3   0.286786
3       4   0.224967
4       5   0.265169
5       6   0.298549
6       7   0.283781
7       8   0.277745
8       9   0.259741
9      10   0.319497
10     11   0.242813
11     12   0.242541
12     13   0.250901
13     14   0.226836
14     15   0.251928
15     16   0.241457
16     17   0.216051
17     18   0.249811
18     19   0.250122
19     20   0.218490
20     21   0.325888
21     22   0.283764
22     23   0.278811
23     24   0.232686
24     25   0.269970
25     26   0.276047
26     27   0.280551
27     28   0.233127
28     29   0.306882
29     30   0.311298
30     31   0.261577
31     32   0.220914
32     33   0.266524
33     34   0.284163
34     35   0.270563
35     36   0.338614
36     37   0.245206
37     38   0.276942
38     39   0.250971
39     40   0.280872
40     41   0.276071
41     42   0.300093
42     43   0.307184
43     44   0.257726
44     45   0.306135
45     46   0.273822
46     47   0.262608
47     48   0.378125
48     49   0.294183
49     50   0.286335
50     51   0.283817
51     52   0.267148
52     53   0.319488
53     54   0.323004
54     55   0.345211
55     56   0.269489
56     57   0.255798
57     58   0.287115
58     59   0.294210
59     60   0.290621
60     61   0.289900
61     62   0.288448
62     63   0.253891
63     64   0.268199
64     65   0.252403
65     66   0.281063
66     67   0.252530
67     68   0.295406
68     69   0.268061
69     70   0.273391
70     71   0.283772
71     72   0.284394
72     73   0.281844
73     74   0.251293
74     75   0.260962
75     76   0.250926
76     77   0.293186
77     78   0.218862
78     79   0.283295
79     80   0.284530
80     81   0.307522
81     82   0.315946
82     83   0.302566
83     84   0.336785
84     85   0.366125
85     86   0.286548
86     87  15.357494
87     88  16.566162
88     89  15.645807
89     90  14.451786
90     91  14.285497
```
